### PR TITLE
Update requirements in composer.json to SS 3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "email": "unclecheese@leftandmain.com"
     }],
     "require": {
-        "silverstripe/framework": "3.*"
+        "silverstripe/framework": ">=3.1.x-dev,<4.0"
     }
     
 }


### PR DESCRIPTION
As the master branch now only works on SS 3.1, I've updated the composer.json requirements so that composer will know never to install this branch on a SS 3.0 site.
