### PR TITLE
Added save button to new records

### DIFF
--- a/code/GridFieldBetterButtonsItemRequest.php
+++ b/code/GridFieldBetterButtonsItemRequest.php
@@ -52,6 +52,13 @@ class GridFieldBetterButtonsItemRequest extends DataExtension {
 		$actions = FieldList::create();
 		// New records
 		if($this->owner->record->ID == 0) {
+			// Just save the record
+			$actions->push(FormAction::create('doSave', _t('GridFieldDetailForm.SAVE', 'Save'))
+					->setUseButtonTag(true)
+					->addExtraClass('ss-ui-action-constructive')
+					->setAttribute('data-icon', 'accept')
+			);
+			
 			// Creates a record and offers a blank form to create another
 			$actions->push(FormAction::create("doSaveAndAdd", _t('GridFieldBetterButtons.SAVEANDADD','Save and add another'))
 					->setUseButtonTag(true)


### PR DESCRIPTION
I really think we should add a save button to new records. Because in ModelAdmin sometimes I have has_many or many_many that only show up after save, so its bit annoying that I only have the choice to save and close or save and add new.

Besides some users would like to save and check if they filled in everything perfect again and if it saved well.
