### PR TITLE
JavaScript error when saving a new dataobject

### DIFF
--- a/code/GridFieldBetterButtonsItemRequest.php
+++ b/code/GridFieldBetterButtonsItemRequest.php
@@ -463,6 +463,7 @@ class GridFieldBetterButtonsItemRequest extends DataExtension {
 			}
 			return $responseNegotiator->respond($controller->getRequest());
 		}
+		Controller::curr()->getResponse()->addHeader('X-Reload', true);
 		return Controller::curr()->redirect($redirectLink);
 	}
 


### PR DESCRIPTION
I was getting a javascript error with I create a new record by clicking the "Save and Close" button. 

after a bit of messing around found that if I add 

```
    Controller::curr()->getResponse()->addHeader('X-Reload', true);
```

to the GridFieldBetterButtonsItemRequest.php it works. 

this happens because the LeftAndMain only follow redirects if the X-Reload is true.
