### PR TITLE
added check against canDelete BetterButton_Delete

### DIFF
--- a/code/BetterButton.php
+++ b/code/BetterButton.php
@@ -90,7 +90,7 @@ class BetterButton_Delete extends BetterButton
 
 
 	public function shouldDisplay() {
-		return !$this->request->recordIsPublished();
+		return $this->request->record->canDelete() && !$this->request->recordIsPublished();
 	}
 
 }


### PR DESCRIPTION
This behavior should better mimic how SilverStripe allows deletion.
Even though you received a warning previously, this removes the Delete
button altogether when deletion is not allowed.
