### PR TITLE
Links not rendered correctly

### DIFF
--- a/code/extensions/GridFieldBetterButtonsItemRequest.php
+++ b/code/extensions/GridFieldBetterButtonsItemRequest.php
@@ -296,14 +296,12 @@ class GridFieldBetterButtonsItemRequest extends DataExtension {
         }
 
 
-        $link = '<a href="' . $this->owner->Link('edit') . '">"'
-            . Convert::raw2xml($this->owner->record->Title)
-            . '"</a>';
-        $message = sprintf(
-            'Published %s %s',
-            $this->owner->record->i18n_singular_name(),
-            $link
-        );
+		$title = '"' . Convert::raw2xml($this->owner->record->Title) . '"';
+		$message = sprintf(
+			'Published %s %s',
+			$this->owner->record->i18n_singular_name(),
+			$title
+		);
 
         $form->sessionMessage($message, 'good');
 


### PR DESCRIPTION
Apparently there have been some security changes that mean links are not rendered correctly inside messages (they escape the html now). I have replaced with just the title.
