### PR TITLE
Removed header from saveAndRedirect()

### DIFF
--- a/code/extensions/GridFieldBetterButtonsItemRequest.php
+++ b/code/extensions/GridFieldBetterButtonsItemRequest.php
@@ -457,7 +457,6 @@ class GridFieldBetterButtonsItemRequest extends DataExtension {
 			}
 			return $responseNegotiator->respond($controller->getRequest());
 		}
-        Controller::curr()->getResponse()->addHeader('X-Reload', true);
             
 		return Controller::curr()->redirect($redirectLink);
 	}


### PR DESCRIPTION
Removed a line of code in `saveAndRedirect()` which was causing the browser to do a hard refresh rather than doing it via javascript.

``` php
Controller::curr()->getResponse()->addHeader('X-Reload', true);
```

After removing this line from the function actions now behave as expected.
