### PR TITLE
FEATURE: allow better buttons to be entirely disabled on certain dataobjects

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,3 +190,11 @@ Sometimes, you might not want to sent a request to the controller at all. For th
 
 ![Screenshot](http://i.cubeupload.com/YbbhL7.png)
 
+### Disabling Better Buttons
+
+Sometimes you might find it necessary to disable better buttons on certain classes. You can do this by changing the static `better_buttons_enabled` to be false via YML configuration.
+
+```yml
+MyBetterButtonLessClass
+  better_buttons_enabled: false
+```

--- a/code/extensions/BetterButtonDataObject.php
+++ b/code/extensions/BetterButtonDataObject.php
@@ -14,6 +14,13 @@
  */
 class BetterButtonDataObject extends DataExtension {
 
+    /**
+     * Enable better buttons for this DataObject
+     *
+     * @config
+     * @var bool
+     */
+    private static $better_buttons_enabled = true;
     
     /**
      * Gets the default actions for all DataObjects. Can be overloaded in subclasses

--- a/code/extensions/GridFieldBetterButtonsItemRequest.php
+++ b/code/extensions/GridFieldBetterButtonsItemRequest.php
@@ -70,6 +70,9 @@ class GridFieldBetterButtonsItemRequest extends DataExtension {
 	 * @param Form The ItemEditForm object
 	 */
 	public function updateItemEditForm($form) {
+		if ($this->getRecord()->stat('better_buttons_enabled') !== true) {
+			return false;
+		}
 		Requirements::css(BETTER_BUTTONS_DIR.'/css/gridfield_betterbuttons.css');
 		Requirements::javascript(BETTER_BUTTONS_DIR.'/javascript/gridfield_betterbuttons.js');
         


### PR DESCRIPTION
This allows you to config out whether better buttons should be used for certain classes. Allows interoperability with [silverstripe-catalogmanager](https://github.com/Little-Giant/silverstripe-catalogmanager) as noted in this issue: https://github.com/Little-Giant/silverstripe-catalogmanager/issues/5
