### PR TITLE
BUGFIX: incorrect reference to non-existant method getRecord

### DIFF
--- a/code/extensions/GridFieldBetterButtonsItemRequest.php
+++ b/code/extensions/GridFieldBetterButtonsItemRequest.php
@@ -70,7 +70,7 @@ class GridFieldBetterButtonsItemRequest extends DataExtension {
 	 * @param Form The ItemEditForm object
 	 */
 	public function updateItemEditForm($form) {
-		if ($this->getRecord()->stat('better_buttons_enabled') !== true) {
+        if ($this->owner->record->stat('better_buttons_enabled') !== true) {
 			return false;
 		}
 		Requirements::css(BETTER_BUTTONS_DIR.'/css/gridfield_betterbuttons.css');


### PR DESCRIPTION
Fixes https://github.com/unclecheese/silverstripe-gridfield-betterbuttons/issues/72

Sorry.
