### PR TITLE
FIX Protect against links that may have anchors

### DIFF
--- a/code/actions/BetterButtonFrontendLinksAction.php
+++ b/code/actions/BetterButtonFrontendLinksAction.php
@@ -34,12 +34,15 @@ class BetterButtonFrontendLinksAction extends BetterButtonAction {
      */
     public function getButtonHTML() {
         $link = $this->getButtonLink();
+        
+        $stageLink = Controller::join_links($link, '?stage=Stage');
+        $liveLink = Controller::join_links($link, '?stage=Live');
 
         return '<span class="better-buttons-frontend-links">
-                    <a class="better-buttons-frontend-link" target="_blank" href="'.$link.'?stage=Stage">'
+                    <a class="better-buttons-frontend-link" target="_blank" href="' . $stageLink . '">'
                         ._t('GridFieldBetterButtons.VIEWONDRAFTSITE','Draft site').
                     '</a> |
-                    <a class="better-buttons-frontend-link" target="_blank" href="'.$link.'?stage=Live">'.
+                    <a class="better-buttons-frontend-link" target="_blank" href="' . $liveLink . '">'.
                         _t('GridFieldBetterButtons.VIEWONLIVESITE','Live site').
                     '</a></span>';
 


### PR DESCRIPTION
This protects against links that may have anchors (#acnchor) at the end of the URL by using `Controller::join_links()` to join the stage query string to the link variable.