### PR TITLE
BUGFIX: use proper save mechanism to save objects

### DIFF
--- a/code/extensions/GridFieldBetterButtonsItemRequest.php
+++ b/code/extensions/GridFieldBetterButtonsItemRequest.php
@@ -269,8 +269,7 @@ class GridFieldBetterButtonsItemRequest extends DataExtension {
         }
 
         try {
-            $form->saveInto($this->owner->record);
-            $this->owner->record->write();
+            $this->save($data, $form);
             $list->add($this->owner->record, $extraData);
             $this->owner->record->invokeWithExtensions('onBeforePublish', $this->owner->record);
             $this->owner->record->publish('Stage', 'Live');


### PR DESCRIPTION
When using a versioned record editor outside of the CMS, the save function saves to the Live record, which is promptly overwritten by the staged record. This change allows the record Stage to be saved then updated to the Live record through the publish action.