### PR TITLE
MINOR: formatting improvements

### DIFF
--- a/css/dropdown_form_action.css
+++ b/css/dropdown_form_action.css
@@ -8,6 +8,7 @@
 	left: 0;
 	bottom: 120%;
 	display:none;
+	width: 300px;
 }
 
 .dropdown-form-action-container {
@@ -108,7 +109,7 @@
 
 
 .dropdown-form-action .dropdown-form-action-menu li > button{
-	padding-left:32px;
+	padding-left:17px;
 	position: relative;
 }
 .dropdown-form-action .dropdown-form-action-menu li > button:after{


### PR DESCRIPTION
bubble is not wide enough to show titles properly with two results:
1. left alignment gets lost
2. overflow of button text out of the "group" bubble