### PR TITLE
Always save draft to Stage regardless of reading mode

### DIFF
--- a/code/extensions/GridFieldBetterButtonsItemRequest.php
+++ b/code/extensions/GridFieldBetterButtonsItemRequest.php
@@ -230,8 +230,8 @@ class GridFieldBetterButtonsItemRequest extends DataExtension {
      * @return SS_HTTPResponse
      */
 	public function save($data, $form) {
-            if(Session::get('readingMode') != "Stage.Stage") {
-                Session::set('readingMode', 'Stage.Stage');
+            if(Versioned::current_stage() != "Stage.Stage") {
+                Versioned::reading_stage('Stage');
             }
 
             return $this->owner->doSave($data, $form);

--- a/code/extensions/GridFieldBetterButtonsItemRequest.php
+++ b/code/extensions/GridFieldBetterButtonsItemRequest.php
@@ -230,7 +230,11 @@ class GridFieldBetterButtonsItemRequest extends DataExtension {
      * @return SS_HTTPResponse
      */
 	public function save($data, $form) {
-		return $this->owner->doSave($data, $form);
+            if(Session::get('readingMode') != "Stage.Stage") {
+                Session::set('readingMode', 'Stage.Stage');
+            }
+
+            return $this->owner->doSave($data, $form);
 	}
 
 

--- a/code/extensions/GridFieldBetterButtonsItemRequest.php
+++ b/code/extensions/GridFieldBetterButtonsItemRequest.php
@@ -230,12 +230,13 @@ class GridFieldBetterButtonsItemRequest extends DataExtension {
      * @return SS_HTTPResponse
      */
 	public function save($data, $form) {
-            if(Versioned::current_stage() != "Stage.Stage") {
-                Versioned::reading_stage('Stage');
-            }
-
-            return $this->owner->doSave($data, $form);
-	}
+            $origStage = Versioned::current_stage();
+            Versioned::reading_stage('Stage');
+            $action = $this->owner->doSave($data, $form);
+            Versioned::reading_stage($origStage);
+            
+            return $action;
+       	}
 
 
     /**


### PR DESCRIPTION
In the existing code, when saving a record there is no check as to what the reading mode may be. If the reading mode is "Stage", it performs as expected, but if the reading mode is "Live", a draft record is cut on the "Live" table. Expected behavior would be for a record to always be cut on the "Stage" table when the Save button is clicked (see issue #80).

This change checks to see if the reading mode is set to "Live" and, if it is, it sets the reading mode to "Stage." That way, the Save button always writes to the Stage table, while the Save & Publish button writes to the Stage table first, and then publishes to the Live table, as expected.