### PR TITLE
ModelAdmin displays most recent version of DataObjects regardless of reading mode

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -7,6 +7,9 @@ DataObject:
 GridFieldDetailForm_ItemRequest:
   extensions:
     - GridFieldBetterButtonsItemRequest
+ModelAdmin:
+  extensions:
+    - BetterButtonsModelAdmin
 BetterButtonsUtils:
   edit:
     BetterButtonPrevNextAction: true

--- a/code/extensions/BetterButtonsModelAdmin.php
+++ b/code/extensions/BetterButtonsModelAdmin.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Decorates {@link ModelAdmin} to show all relevant records,
+ * including unpublished Versioned DataObjects
+ * even if in Live reading mode.
+ *
+ * @author  Isaiah Keepin <isaiah@bluehousegroup.com>
+ * @package  silverstripe-gridfield-betterbuttons
+ *
+ * */
+class BetterButtonsModelAdmin extends Extension {
+    public function updateEditForm(&$form) {
+        $origStage = Versioned::current_stage();
+        if($origStage != "Stage") {
+            Versioned::reading_stage('Stage');
+            $fields = $form->Fields();
+            foreach($fields as &$field) {
+                if($field->class == "GridField") {
+                    $stage_data = Versioned::get_by_stage($this->owner->modelClass, "Stage");
+                    $field->setList($stage_data);
+                }
+            }
+            Versioned::reading_stage($origStage);
+        }
+    }
+}

--- a/code/extensions/BetterButtonsModelAdmin.php
+++ b/code/extensions/BetterButtonsModelAdmin.php
@@ -13,7 +13,6 @@ class BetterButtonsModelAdmin extends Extension {
     public function updateEditForm(&$form) {
         $origStage = Versioned::current_stage();
         if($origStage != "Stage") {
-            Versioned::reading_stage('Stage');
             $fields = $form->Fields();
             foreach($fields as &$field) {
                 if($field->class == "GridField") {
@@ -21,7 +20,6 @@ class BetterButtonsModelAdmin extends Extension {
                     $field->setList($stage_data);
                 }
             }
-            Versioned::reading_stage($origStage);
         }
     }
 }

--- a/code/extensions/GridFieldBetterButtonsItemRequest.php
+++ b/code/extensions/GridFieldBetterButtonsItemRequest.php
@@ -246,6 +246,8 @@ class GridFieldBetterButtonsItemRequest extends DataExtension {
      */
     public function publish($data, $form, $request = null, $redirectURL = null)
     {
+        $origStage = Versioned::current_stage();
+        Versioned::reading_stage('Stage');
 
         $new_record = $this->owner->record->ID == 0;
         $controller = Controller::curr();
@@ -279,6 +281,7 @@ class GridFieldBetterButtonsItemRequest extends DataExtension {
             $this->owner->record->invokeWithExtensions('onBeforePublish', $this->owner->record);
             $this->owner->record->publish('Stage', 'Live');
             $this->owner->record->invokeWithExtensions('onAfterPublish', $this->owner->record);
+            Versioned::reading_stage($origStage);
         } catch (ValidationException $e) {
             $form->sessionMessage($e->getResult()->message(), 'bad');
             $responseNegotiator = new PjaxResponseNegotiator(array(
@@ -430,6 +433,8 @@ class GridFieldBetterButtonsItemRequest extends DataExtension {
 	 * @todo  GridFieldDetailForm_ItemRequest::doSave is too monolithic, making overloading impossible. Most of this code is a direct copy.
 	 * */
 	protected function saveAndRedirect($data, $form, $redirectLink) {
+		$origStage = Versioned::current_stage();
+		Versioned::reading_stage('Stage');
 		$new_record = $this->owner->record->ID == 0;
 		$controller = Controller::curr();
 		$list = $this->owner->gridField->getList();
@@ -449,6 +454,7 @@ class GridFieldBetterButtonsItemRequest extends DataExtension {
 			$form->saveInto($this->owner->record);
 			$this->owner->record->write();
 			$list->add($this->owner->record, $extraData);
+			Versioned::reading_stage($origStage);
 		} catch(ValidationException $e) {
 			$form->sessionMessage($e->getResult()->message(), 'bad');
 			$responseNegotiator = new PjaxResponseNegotiator(array(


### PR DESCRIPTION
This change addresses issues encountered when using BetterButtons with Versioned DataObjects. It expands on the change made in pull request #83, and resolves the issue raised in #84 (and, as far as I can tell, #85 as well).

Without this change, using ModelAdmin with Versioned DataObjects in Live reading mode gives a variety of unexpected results (described in issues #84 and #85). This problem is compounded by not being able to tell, from the cms back end, which reading mode we are in. The user's natural expectation is that CRUD for Versioned DataObjects would work the same regardless of reading mode, which is how CRUD for Pages works also.

The source of the problem is that in Live mode, we cannot save to or read from the Stage table for a Versioned DataObject. 

As for the saving problem, pull request #83 begins to solve the problem by ensuring the save() function happens in Stage mode; this pull request expands on that solution by ensuring that publish() and saveAndRedirect() also happen in Stage mode. The same method is used here, including returning the reading mode to whatever it was previously.

As for the reading problem, this pull request introduces a new extension, BetterButtonsModelAdmin, that ensures data is loaded from the Stage table regardless of reading mode, since this will contain the most recent version of a Versioned DataObject.