### PR TITLE
Removing $successMessage code

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,13 +159,12 @@ Now we have a new button in the UI!
 ![Screenshot](http://i.cubeupload.com/hoU66o.png)
 
 ### Customising the user experience
-Let's ensure that the form refreshes after clicking "approve" or "deny". Additionally, we'll add a success message that will render on completion of the action.
+Let's ensure that the form refreshes after clicking "approve" or "deny".
 
 ```php
   $fields->push(
     BetterButtonCustomAction::create('deny', 'Deny')
       ->setRedirectType(BetterButtonCustomAction::REFRESH)
-      ->setSuccessMessage('Denied for publication')
   );
 ```
 
@@ -175,6 +174,17 @@ BetterButtonCustomAction::REFRESH
 BetterButtonCustomAction::GOBACK
 ```
 To refresh the form, or go back to list view, respectively.
+
+Additionally, we can add a success message that will render on completion of the action by returning a message in our method.
+
+```php
+    public function deny() {
+        $this->IsApproved = false;
+        $this->write();
+
+        return 'Denied for publication';
+    }
+```
 
 ### Defining arbitrary links
 Sometimes, you might not want to sent a request to the controller at all. For that, there's the much simpler ```BetterButtonLink``` class.

--- a/code/actions/BetterButtonCustomAction.php
+++ b/code/actions/BetterButtonCustomAction.php
@@ -43,13 +43,6 @@ class BetterButtonCustomAction extends BetterButtonAction {
 
 
     /**
-     * The success message on completion of the action
-     * @var  string
-     */
-    protected $successMessage;
-
-
-    /**
      * Builds the button
      * @param string                          $actionName   The name of the action (method)
      * @param string                          $text         The text for the button
@@ -118,27 +111,6 @@ class BetterButtonCustomAction extends BetterButtonAction {
      */
     public function getRedirectURL() {
         return $this->redirectURL;
-    }
-
-
-    /**
-     * Sets the success message when action complets
-     * @param string $message
-     * @return  BetterButtonCustomAction
-     */
-    public function setSuccessMessage($message) {
-        $this->successMessage = $message;
-
-        return $this;
-    }
-
-
-    /**
-     * Gets the success message
-     * @return string
-     */
-    public function getSuccessMessage() {
-        return $this->successMessage;
     }
 
 


### PR DESCRIPTION
Removing `$successMessage` code, which is no longer used. 

Updating docmentation to show how success messages are now set.

This is related to issue #102 