### PR TITLE
Create conditional that checks state to properly display saved / save draft button

### DIFF
--- a/code/buttons/BetterButton_SaveDraft.php
+++ b/code/buttons/BetterButton_SaveDraft.php
@@ -41,4 +41,20 @@ class BetterButton_SaveDraft extends BetterButton implements BetterButton_Versio
             ->setAttribute('data-icon-alternate', 'addpage')
             ->setAttribute('data-text-alternate', _t('CMSMain.SAVEDRAFT', 'Save draft'));
     }
+
+
+    /** 
+     * Update the UI to reflect unsaved state
+     * @return void
+     */
+    public function transformToButton() {
+        parent::transformToButton();
+
+        if($this->gridFieldRequest->recordIsDeletedFromStage()) {
+            $this->addExtraClass('ss-ui-alternate');
+        }
+
+        return $this;
+    }
+
 }


### PR DESCRIPTION
Currently in our project the saved / save draft button is defaulting to saved when we are on a create view with an empty form. This pull request implements a conditional check that has fixed the problem for us.