### PR TITLE
TEST Add initial unit tests, PSR-4 for tests and standard Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 
 env:
   global:
-    - DB=MYSQL CORE_RELEASE=master
+    - DB=MYSQL CORE_RELEASE=4
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: php
+
+env:
+  global:
+    - DB=MYSQL CORE_RELEASE=master
+
+matrix:
+  include:
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+
+before_script:
+    - git clone git://github.com/silverstripe/silverstripe-travis-support.git ~/travis-support
+    - php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss
+    - cd ~/builds/ss
+
+script:
+    - vendor/bin/phpunit betterbuttons/tests
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Better Buttons for GridField
 ====================================
 
+[![Build Status](https://travis-ci.org/unclecheese/silverstripe-gridfield-betterbuttons.svg?branch=master)](https://travis-ci.org/unclecheese/silverstripe-gridfield-betterbuttons)
+
 ![Screenshot](http://i.cubeupload.com/J8vWQf.png)
 
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     },
     "autoload": {
         "psr-4": {
-            "UncleCheese\\BetterButtons\\": "src/"
+            "UncleCheese\\BetterButtons\\": "src/",
+            "UncleCheese\\BetterButtons\\Tests\\": "tests/"
         }
     },
     "minimum-stability": "dev",

--- a/src/Extensions/BetterButtonDataObject.php
+++ b/src/Extensions/BetterButtonDataObject.php
@@ -9,6 +9,7 @@ use SilverStripe\Forms\CompositeField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\ORM\DataExtension;
 use SilverStripe\ORM\Versioning\Versioned;
+use UncleCheese\BetterButtons\Buttons\BetterButton;
 use UncleCheese\BetterButtons\FormFields\DropdownFormAction;
 
 /**
@@ -169,8 +170,8 @@ class BetterButtonDataObject extends DataExtension
      * @param  Form                             $form      The form that will contain the button
      * @param  GridFieldDetailForm_ItemRequest  $request   The request that points to the form
      * @param  boolean                          $button    If the button should display as an input tag or a button
-     * @return FormField
-     * @throws Exception if the requested button type does not exist
+     * @return BetterButton
+     * @throws Exception If the requested button type does not exist
      */
     protected function instantiateButton($className)
     {

--- a/tests/Actions/BetterButtonActionTest.php
+++ b/tests/Actions/BetterButtonActionTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace UncleCheese\BetterButtons\Tests\Actions;
+
+use SilverStripe\Dev\SapphireTest;
+use UncleCheese\BetterButtons\Actions\BetterButtonAction;
+
+class BetterButtonActionTest extends SapphireTest
+{
+    /**
+     * Test that the button name (or button text) is sanitized and returned as lowercase
+     *
+     * @dataProvider buttonNameProvider
+     * @param string $buttonName
+     * @param string $expected
+     */
+    public function testGetButtonName($buttonName, $expected)
+    {
+        $field = new BetterButtonAction($buttonName);
+        $this->assertSame($expected, $field->getButtonName());
+    }
+
+    /**
+     * @return array[]
+     */
+    public function buttonNameProvider()
+    {
+        return [
+            [
+                'MyGenericButton123',
+                'mygenericbutton123'
+            ],
+            [
+                '!@#$%^&*()',
+                ''
+            ],
+            [
+                '#better!button#',
+                'betterbutton'
+            ]
+        ];
+    }
+}

--- a/tests/Actions/BetterButtonCustomActionTest.php
+++ b/tests/Actions/BetterButtonCustomActionTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace UncleCheese\BetterButtons\Tests\Actions;
+
+use SilverStripe\Dev\SapphireTest;
+use UncleCheese\BetterButtons\Actions\BetterButtonCustomAction;
+
+class BetterButtonCustomActionTest extends SapphireTest
+{
+    /**
+     * @var BetterButtonCustomAction
+     */
+    private $button;
+
+    /**
+     * Instantiate the test button
+     *
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->button = new BetterButtonCustomAction('foo', 'bar');
+    }
+
+    /**
+     * Test that setRedirectType will throw an exception if you provide an unrecognised redirect type
+     *
+     * @expectedException Exception
+     * @expectedExceptionMessage Redirect type must use either the GOBACK or REFRESH constants
+     * on BetterButtonCustomAction
+     */
+    public function testSetRedirectThrowsExceptionOnInvalidType()
+    {
+        $this->button->setRedirectType(12345);
+    }
+
+    /**
+     * Test that a valid redirect type can be set and retrieved
+     */
+    public function testSetAndGetRedirectType()
+    {
+        $this->button->setRedirectType(BetterButtonCustomAction::REFRESH);
+        $this->assertSame(BetterButtonCustomAction::REFRESH, $this->button->getRedirectType());
+    }
+
+    /**
+     * Test that the redirect URL can be set and retrieved
+     */
+    public function testSetAndGetRedirectUrl()
+    {
+        $this->button->setRedirectURL('leftandmain.com');
+        $this->assertSame('leftandmain.com', $this->button->getRedirectURL());
+    }
+}

--- a/tests/Extensions/BetterButtonDataObjectTest.php
+++ b/tests/Extensions/BetterButtonDataObjectTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace UncleCheese\BetterButtons\Tests\Actions;
+
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Forms\FieldList;
+use UncleCheese\BetterButtons\Buttons\BetterButton_SaveAndClose;
+use UncleCheese\BetterButtons\Interfaces\BetterButtonInterface;
+use UncleCheese\BetterButtons\Tests\Extensions\Stubs\ButtonDataObject;
+
+class BetterButtonDataObjectTest extends SapphireTest
+{
+    protected $usesDatabase = true;
+
+    protected $extraDataObjects = [
+        ButtonDataObject::class
+    ];
+
+    /**
+     * Nest the configuration so that we can play around with it
+     *
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        Config::nest();
+    }
+
+    /**
+     * Test that the getBetterButtonsActions method returns a FieldList containing the configured actions for
+     * the DataObject
+     */
+    public function testGetBetterButtonActions()
+    {
+        Config::inst()->update('BetterButtonsActions', 'create', [
+            'BetterButton_SaveAndClose' => true
+        ]);
+
+        Config::inst()->update('BetterButtonsActions', 'delete', [
+            'BetterButton_Delete' => false
+        ]);
+
+        $object = new ButtonDataObject;
+        $result = $object->getBetterButtonsActions();
+
+        $this->assertInstanceOf(FieldList::class, $result);
+
+        $this->assertInstanceOf(BetterButton_SaveAndClose::class, $result->fieldByName('action_doSaveAndQuit'));
+        $this->assertNull($result->fieldByName('action_doDelete'));
+    }
+
+    /**
+     * Test that all fields in the button FieldList are instances of BetterButtonInterface. Uses the default
+     * configuration from _config/config.yml
+     */
+    public function testAllButtonsImplementInterface()
+    {
+        $object = new ButtonDataObject;
+        $fields = $object->getBetterButtonsActions();
+        $this->assertContainsOnlyInstancesOf(BetterButtonInterface::class, $fields);
+    }
+
+    /**
+     * Test that the instantiateButton method throws an exception if the button could not be created, essentially
+     * if there is no injector mapping for the given button name
+     *
+     * @expectedException Exception
+     * @expectedExceptionMessage The button type DonkeyLlamaChild doesn't exist.
+     */
+    public function testInstantiateButtonThrowsExceptionOnInvalidButtonClass()
+    {
+        Config::inst()->update('BetterButtonsActions', 'create', [
+            'MicroHamsterPidgeon' => false, // Will pass, since it's not enabled
+            'DonkeyLlamaChild' => true
+        ]);
+
+        $object = new ButtonDataObject;
+        $object->getBetterButtonsActions();
+    }
+
+    /**
+     * ButtonDataObject is not versioned, so test that checkVersioned reports that too
+     */
+    public function testButtonDataObjectIsNotVersioned()
+    {
+        $this->assertFalse((new ButtonDataObject)->checkVersioned());
+    }
+
+    /**
+     * Un-nest the configuration - we're finished playing
+     *
+     * {@inheritDoc}
+     */
+    public function tearDown()
+    {
+        Config::unnest();
+        parent::tearDown();
+    }
+}

--- a/tests/Extensions/Stubs/ButtonDataObject.php
+++ b/tests/Extensions/Stubs/ButtonDataObject.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace UncleCheese\BetterButtons\Tests\Extensions\Stubs;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use UncleCheese\BetterButtons\Extensions\BetterButtonDataObject;
+
+/**
+ * A mock DataObject that has the BetterButtonDataObject extension applied, for testing
+ */
+class ButtonDataObject extends DataObject implements TestOnly
+{
+    private static $table_name = 'TestButtonDataObject';
+
+    private static $extensions = [
+        BetterButtonDataObject::class
+    ];
+}


### PR DESCRIPTION
## Test

This pull request adds a couple of basic unit tests for a couple of the classes, including the creation of button instances from configuration for a DataObject with the extension applied.

* Adds standard Travis configuration