### PR TITLE
ISSUE 167: Remove deprecated DataModel class from BetterButtonsItemRequest

### DIFF
--- a/src/Extensions/GridFieldBetterButtonsItemRequest.php
+++ b/src/Extensions/GridFieldBetterButtonsItemRequest.php
@@ -14,7 +14,6 @@ use SilverStripe\Forms\GridField\GridFieldDetailForm_ItemRequest;
 use SilverStripe\Forms\TabSet;
 use SilverStripe\ORM\DataExtension;
 use SilverStripe\ORM\DataList;
-use SilverStripe\ORM\DataModel;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
 use SilverStripe\ORM\ManyManyList;
@@ -72,7 +71,7 @@ class GridFieldBetterButtonsItemRequest extends DataExtension
     {
         $req = new BetterButtonsCustomActionRequest($this, $this->owner, $this->owner->ItemEditForm());
 
-        return $req->handleRequest($r, DataModel::inst());
+        return $req->handleRequest($r);
     }
 
     /**
@@ -86,7 +85,7 @@ class GridFieldBetterButtonsItemRequest extends DataExtension
     {
         $req = new BetterButtonsNestedFormRequest($this, $this->owner, $this->owner->ItemEditForm());
 
-        return $req->handleRequest($r, DataModel::inst());
+        return $req->handleRequest($r);
     }
 
     /**


### PR DESCRIPTION
DataModel is removed in SS4. `handleRequest` no longer requires a second parameter. This fixes issue #167 