### PR TITLE
Fix module and resource loading for SS 4.1.0

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -1,3 +1,0 @@
-<?php
-
-define('BETTER_BUTTONS_DIR', basename(dirname(__FILE__)));

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "unclecheese/betterbuttons",
     "description": "Adds new form actions and buttons to GridField detail form for usability enhancements.",
-    "type": "silverstripe-module",
+    "type": "silverstripe-vendormodule",
     "keywords": ["silverstripe", "gridfield", "buttons"],
     "license": "GNU",
     "authors": [
@@ -11,12 +11,18 @@
         }
     ],
     "require": {
+        "silverstripe/vendor-plugin": "^1.0",
         "silverstripe/framework": "^4.0@dev"
     },
     "extra": {
         "branch-alias": {
             "dev-master": "2.x-dev"
-        }
+        },
+        "expose": [
+            "css",
+            "images",
+            "javascript"
+        ]
     },
     "autoload": {
         "psr-4": {

--- a/css/gridfield_betterbuttons.css
+++ b/css/gridfield_betterbuttons.css
@@ -1,6 +1,16 @@
 .cms .gridfield-better-buttons-prevnext.disabled { opacity: 0.3; filter: alpha(opacity=30); }
 
-.cms .gridfield-better-buttons-prevnext img { height:7px; vertical-align:1px; }
+.cms .gridfield-better-buttons-prev {
+	background: url('../images/prev.png') no-repeat center center;
+	background-position-x: 2px;
+	padding-left: 22px;
+}
+
+.cms .gridfield-better-buttons-next {
+	background: url('../images/next.png') no-repeat center center;
+	background-position-x: 100%;
+	padding-right: 22px;
+}
 
 .cms .gridfield-better-buttons-prevnext .ui-button-text { line-height:1; }
 

--- a/src/Actions/BetterButtonPrevNextAction.php
+++ b/src/Actions/BetterButtonPrevNextAction.php
@@ -38,7 +38,7 @@ class BetterButtonPrevNextAction extends BetterButtonAction
         $linkText = $previousRecordID ? _t('GridFieldBetterButtons.PREVIOUS', 'Previous') : "";
 
         $html .= sprintf(
-            "<a class='ss-ui-button btn btn-default gridfield-better-buttons-prevnext gridfield-better-buttons-prev %s' href='%s' title='%s'><img src='".BETTER_BUTTONS_DIR."/images/prev.png' alt='previous'  /> %s</a>",
+            "<a class='ss-ui-button btn btn-default gridfield-better-buttons-prevnext gridfield-better-buttons-prev %s' href='%s' title='%s'>%s</a>",
             $cssClass,
             $prevLink,
             $linkTitle,
@@ -53,7 +53,7 @@ class BetterButtonPrevNextAction extends BetterButtonAction
         $linkText = $nextRecordID ? _t('GridFieldBetterButtons.NEXT', 'Next') : "";
 
         $html .= sprintf(
-            "<a class='ss-ui-button btn btn-default gridfield-better-buttons-prevnext gridfield-better-buttons-next %s' href='%s' title='%s'>%s <img src='".BETTER_BUTTONS_DIR."/images/next.png' alt='next'  /></a>",
+            "<a class='ss-ui-button btn btn-default gridfield-better-buttons-prevnext gridfield-better-buttons-next %s' href='%s' title='%s'>%s</a>",
             $cssClass,
             $nextLink,
             $linkTitle,

--- a/src/Buttons/BetterButton_Delete.php
+++ b/src/Buttons/BetterButton_Delete.php
@@ -28,7 +28,7 @@ class BetterButton_Delete extends BetterButton
     public function baseTransform()
     {
         parent::baseTransform();
-        Requirements::javascript(BETTER_BUTTONS_DIR.'/javascript/gridfield_betterbuttons_delete.js');
+        Requirements::javascript('unclecheese/betterbuttons:javascript/gridfield_betterbuttons_delete.js');
 
         return $this
             ->setUseButtonTag(true)

--- a/src/Controllers/BetterButtonsNestedFormRequest.php
+++ b/src/Controllers/BetterButtonsNestedFormRequest.php
@@ -75,7 +75,7 @@ class BetterButtonsNestedFormRequest extends BetterButtonsCustomActionRequest
      */
     public function index(HTTPRequest $r)
     {
-        Requirements::css(BETTER_BUTTONS_DIR.'/css/betterbuttons_nested_form.css');
+        Requirements::css('unclecheese/betterbuttons:css/betterbuttons_nested_form.css');
 
         return $this->customise(array(
             'Form' => $this->Form()

--- a/src/Extensions/GridFieldBetterButtonsItemRequest.php
+++ b/src/Extensions/GridFieldBetterButtonsItemRequest.php
@@ -111,8 +111,8 @@ class GridFieldBetterButtonsItemRequest extends DataExtension
         if ($this->owner->record->stat('better_buttons_enabled') !== true) {
             return false;
         }
-        Requirements::css(BETTER_BUTTONS_DIR.'/css/gridfield_betterbuttons.css');
-        Requirements::javascript(BETTER_BUTTONS_DIR.'/javascript/gridfield_betterbuttons.js');
+        Requirements::css('unclecheese/betterbuttons:css/gridfield_betterbuttons.css');
+        Requirements::javascript('unclecheese/betterbuttons:javascript/gridfield_betterbuttons.js');
 
 
         $actions = $this->owner->record->getBetterButtonsActions();

--- a/src/FormFields/DropdownFormAction.php
+++ b/src/FormFields/DropdownFormAction.php
@@ -61,8 +61,8 @@ class DropdownFormAction extends CompositeField implements BetterButtonInterface
      */
     public function Field($properties = array ())
     {
-        Requirements::css(BETTER_BUTTONS_DIR . '/css/dropdown_form_action.css');
-        Requirements::javascript(BETTER_BUTTONS_DIR . '/javascript/dropdown_form_action.js');
+        Requirements::css('unclecheese/betterbuttons:css/dropdown_form_action.css');
+        Requirements::javascript('unclecheese/betterbuttons:javascript/dropdown_form_action.js');
         $this->setAttribute('data-form-action-dropdown', '#' . $this->DropdownID());
 
         return parent::Field();


### PR DESCRIPTION
I'm not sure if this will continue to work on 4.0.* (I haven't tested)

I couldn't work out how to get the correct resource path for images, so did them in css instead (this seems to be how all of the core silverstripe modules load images).

Should address #175 