### PR TITLE
FIX (1.3): Better maintenance of state for the save draft + publish buttons

### DIFF
--- a/code/buttons/BetterButton_Publish.php
+++ b/code/buttons/BetterButton_Publish.php
@@ -54,7 +54,7 @@ class BetterButton_Publish extends BetterButton implements BetterButton_Versione
             $this->setTitle(_t('SiteTree.BUTTONPUBLISHED', 'Published'));
         }
 
-        if($this->gridFieldRequest->record->stagesDiffer('Stage','Live') && $this->gridFieldRequest->recordIsDeletedFromStage()) {
+        if($this->gridFieldRequest->record->stagesDiffer('Stage','Live')) {
             $this->addExtraClass('ss-ui-alternate');
         }
 

--- a/code/extensions/GridFieldBetterButtonsItemRequest.php
+++ b/code/extensions/GridFieldBetterButtonsItemRequest.php
@@ -103,7 +103,6 @@ class GridFieldBetterButtonsItemRequest extends DataExtension {
         $utils = $this->owner->record->getBetterButtonsUtils();
 		$form->Utils = $this->filterFieldList($form, $utils);
 		$form->setTemplate('BetterButtons_EditForm');
-		$form->addExtraClass('better-buttons-form');
 	}
 
 

--- a/javascript/gridfield_betterbuttons.js
+++ b/javascript/gridfield_betterbuttons.js
@@ -25,15 +25,6 @@ $.entwine('ss', function($) {
 			}
 			this._super(e);
 		}
-	});
-
-	// This kills the publish/save button switch that happens on blur in CMSMain.
-	$('.better-buttons-form.cms-edit-form.changed').entwine({
-		onmatch: function(e) {
-		},
-		onunmatch: function(e) {
-		}
-	});
-
+	})	
 });
 })(jQuery);


### PR DESCRIPTION
Addresses to important issues I've identified:

1. Going in to edit a record will not reflect if it has a publishable version or not (33a6fcc)
2. Changing a record doesn't dynamically update the two submit buttons at the bottom like it should (8d4991a)

Granted #​2 is just a revert of another commit (245caaf), however, this functionality is entirely consistent with other `Version`'ed objects, i.e. `SiteTree`. I acknowledge that maintaining this functionality (i.e. button state updating if the form is modified in any way), however I believe that should be classified as a separate bug that should instead be addressed in `silverstripe-cms`, given it is more broad and consistency and, more importantly, visual feedback on current state is more valuable (in my subjective opinion).