### PR TITLE
FIX for #184: Add loading status to "Versioning" button group when clicking a button inside dropdown.

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -48,6 +48,7 @@ BetterButtonsGroups:
       BetterButton_SaveAndPrev: true
   Versioning:
     label: Versioning...
+    icon: arrow-circle-double
     buttons:
       BetterButton_Rollback: true
       BetterButton_Unpublish: true

--- a/code/extensions/BetterButtonDataObject.php
+++ b/code/extensions/BetterButtonDataObject.php
@@ -177,9 +177,11 @@ class BetterButtonDataObject extends DataExtension {
     protected function createButtonGroup($groupName) {        
         $groupConfig = Config::inst()->get("BetterButtonsGroups", $groupName);
         $label = (isset($groupConfig['label'])) ? $groupConfig['label'] : $groupName;
+        $icon = (isset($groupConfig['icon'])) ? $groupConfig['icon'] : '';
         $buttons = (isset($groupConfig['buttons'])) ? $groupConfig['buttons'] : array ();
         $button = DropdownFormAction::create(_t('GridFieldBetterButtons.'.$groupName, $label));
-        foreach($buttons as $b => $bool) {              
+        if ($icon !== '') $button->setAttribute('data-icon', $icon);
+        foreach($buttons as $b => $bool) {
             if($bool) {
                 if($child = $this->instantiateButton($b)) {
                     $button->push($child);

--- a/javascript/dropdown_form_action.js
+++ b/javascript/dropdown_form_action.js
@@ -61,6 +61,11 @@ $.entwine('ss', function($) {
 			}
 
 			this._super();
+		},
+
+		onmouseup: function() {
+		    $("[data-form-action-dropdown]").addClass('loading');
+		    this._super();
 		}
 
 	});


### PR DESCRIPTION
Fix for #184, applies to 1.3.  Allow ability for user to see immediate feedback when submitting form (to reduce confusion).

Turns this:
![2018-11-09_21-52-17](https://user-images.githubusercontent.com/4269377/48298075-94918b00-e46b-11e8-84b5-f393026ad896.gif)


To this:
![2018-11-09_21-51-16](https://user-images.githubusercontent.com/4269377/48298073-90fe0400-e46b-11e8-861d-3c8f2a0f827f.gif)
